### PR TITLE
Fixed vector coloring in raw oflow demo app

### DIFF
--- a/demo/raw/colors.js
+++ b/demo/raw/colors.js
@@ -32,6 +32,6 @@ function convertHsvToRgb(h, s, v) {
 }
 
 function getDirectionalColor(x, y) {
-    var hue = Math.atan2(y, x) * toDegree + 360;
+    var hue = (Math.atan2(y, x) * toDegree + 360) % 360;
     return convertHsvToRgb(hue, 1, 1);
 }


### PR DESCRIPTION
In original version any vector pointing right is colored as red due to hue channel overflow