### PR TITLE
Allow specification of camera direction (for mobile)

### DIFF
--- a/src/webcamFlow.js
+++ b/src/webcamFlow.js
@@ -9,6 +9,9 @@ module.exports = WebCamFlow;
  *   where web camera output should be rendered. If parameter is not
  *   present a new invisible <video> tag is created.
  * @param zoneSize {int} optional size of a flow zone in pixels. 8 by default
+ * @param cameraFacing {string} optional direction camera is facing (either 
+ * 'user' or 'environment') used to give preference to a particlar mobile 
+ * camera. If matching camera is not found, any available one will be used.
  *
  * Usage example:
  *  var flow = new WebCamFlow();
@@ -26,7 +29,7 @@ module.exports = WebCamFlow;
  *  // once you are done capturing call
  *  flow.stopCapture();
  */
-function WebCamFlow(defaultVideoTag, zoneSize) {
+function WebCamFlow(defaultVideoTag, zoneSize, cameraFacing) {
     var videoTag,
         isCapturing,
         localStream,
@@ -46,13 +49,26 @@ function WebCamFlow(defaultVideoTag, zoneSize) {
             });
         },
         initCapture = function() {
-            if (!videoFlow) {
-                videoTag = defaultVideoTag || window.document.createElement('video');
-                videoTag.setAttribute('autoplay', true);
-                videoFlow = new VideoFlow(videoTag, zoneSize);
+        if (!videoFlow) {
+            videoTag = defaultVideoTag || window.document.createElement('video');
+            videoTag.setAttribute('autoplay', true);
+            videoFlow = new VideoFlow(videoTag, zoneSize);
+        }
+
+        window.MediaStreamTrack.getSources(function(sourceInfos) {
+            for (var i = 0; i < sourceInfos.length; i++) {
+                if (sourceInfos[i].kind === 'video'){
+                    selectedVideoSource = sourceInfos[i].id;
+                    // if camera facing requested direction is found, stop search
+                    if (sourceInfos[i].facing === cameraFacing) {
+                        break;
+                    }
+                }
             }
 
-            navigator.getUserMedia({ video: true }, function(stream) {
+            desiredDevice = { optional: [{sourceId: selectedVideoSource}] };
+
+            navigator.getUserMedia({ video: desiredDevice }, function(stream) {
                 isCapturing = true;
                 localStream = stream;
                 videoTag.src = window.URL.createObjectURL(stream);
@@ -61,7 +77,9 @@ function WebCamFlow(defaultVideoTag, zoneSize) {
                     videoFlow.onCalculated(gotFlow);
                 }
             }, onWebCamFail);
-        };
+        });
+
+    };
 
     if (!navigator.getUserMedia) {
         navigator.getUserMedia = navigator.getUserMedia ||


### PR DESCRIPTION
For use of oflow on phones, I needed to specify which camera to connect to (back or front-facing). Perhaps it's useful for others too.