### PR TITLE
Fixes Deprecation of createObjectURL in new browsers

### DIFF
--- a/src/webcamFlow.js
+++ b/src/webcamFlow.js
@@ -75,7 +75,11 @@ function WebCamFlow(defaultVideoTag, zoneSize, cameraFacing) {
                 navigator.getUserMedia({ video: desiredDevice }, function(stream) {
                     isCapturing = true;
                     localStream = stream;
-                    videoTag.src = window.URL.createObjectURL(stream);
+                    if ("srcObject" in videoTag) {
+                        videoTag.srcObject = stream;
+                    } else {
+                        videoTag.src = window.URL.createObjectURL(stream);
+                    }
                     if (stream) {
                         videoFlow.startCapture(videoTag);
                         videoFlow.onCalculated(gotFlow);
@@ -96,7 +100,11 @@ function WebCamFlow(defaultVideoTag, zoneSize, cameraFacing) {
                     navigator.getUserMedia({ video: desiredDevice }, function(stream) {
                         isCapturing = true;
                         localStream = stream;
-                        videoTag.src = window.URL.createObjectURL(stream);
+                        if ("srcObject" in videoTag) {
+                            videoTag.srcObject = stream;
+                        } else {
+                            videoTag.src = window.URL.createObjectURL(stream);
+                        }
                         if (stream) {
                             videoFlow.startCapture(videoTag);
                             videoFlow.onCalculated(gotFlow);


### PR DESCRIPTION
This will fix Deprecation of createObjectURL and replace with the new HTMLMediaElement.srcObject.
Take a look at [Mozila Using the new API in older browsers](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia) and [Stackoverflow Deprecation of createObjectUR](https://stackoverflow.com/questions/51101408/deprecation-of-createobjecturl-and-replace-with-the-new-htmlmediaelement-srcobje)